### PR TITLE
Carousel2.0

### DIFF
--- a/src/components/Carousel/CustomCarousel.js
+++ b/src/components/Carousel/CustomCarousel.js
@@ -182,7 +182,17 @@ export default class CustomCarousel extends React.PureComponent {
       slidesToScroll,
       slidesToShow
     } = this.state;
-    console.log(slidesToShow, slidesToScroll);
+
+    const { shouldUseDynamicArrows } = this.props;
+
+    const isPrevArrowHidden = shouldUseDynamicArrows
+      ? !shouldShowPrevArrow
+      : slidesToShow >= this.props.children.length;
+
+    const isNextArrowHidden = shouldUseDynamicArrows
+      ? !shouldShowNextArrow
+      : slidesToShow >= this.props.children.length;
+
     const settings = {
       infinite: false,
       speed: animationSpeed,
@@ -190,14 +200,14 @@ export default class CustomCarousel extends React.PureComponent {
       slidesToScroll,
       prevArrow: (
         <Arrow
-          isHidden={!shouldShowPrevArrow}
+          isHidden={isPrevArrowHidden}
           type="prev"
           setPrevArrowDisplayState={this.setPrevArrowDisplayState}
         />
       ),
       nextArrow: (
         <Arrow
-          isHidden={!shouldShowNextArrow}
+          isHidden={isNextArrowHidden}
           type="next"
           setNextArrowDisplayState={this.setNextArrowDisplayState}
         />
@@ -209,8 +219,8 @@ export default class CustomCarousel extends React.PureComponent {
     return (
       <div
         style={{
-          paddingLeft: shouldShowPrevArrow ? sidePaddingValue : "0px",
-          paddingRight: shouldShowNextArrow ? sidePaddingValue : "0px"
+          paddingLeft: !isPrevArrowHidden ? sidePaddingValue : "0px",
+          paddingRight: !isNextArrowHidden ? sidePaddingValue : "0px"
         }}
         ref={r => {
           this.carouselElement = r;


### PR DESCRIPTION
Add carousel 2.0! Leaving arrows always visible as discussed but the flag shouldUseDynamicArrows can revert to the spec in the ticket.

## Checklist

- [ ] Latest code from master has been merged into the pull request branch
- [ ] Honors [the seven code virtues](https://pragprog.com/magazines/2011-08/how-virtuous-is-your-code)
  - [ ] Working, as opposed to incomplete
  - [ ] Unique, as opposed to duplicated
  - [ ] Simple, as opposed to complicated
  - [ ] Clear, as opposed to puzzling
  - [ ] Easy, as opposed to difficult
  - [ ] Developed, as opposed to primitive
  - [ ] Brief, as opposed to chatty
- [ ] Code is camelCased
- [ ] No commented out code (if required, place // TODO above with explanation)
- [ ] No linting issues
- [ ] Automated tests exist and pass
- [ ] Build is successful (`npm run build`)
- [ ] Works in IE 11, Chrome, Firefox, and Edge

## Thanks!

:heart:
